### PR TITLE
fix: remove visibility keywords from constructors

### DIFF
--- a/src/Approval.sol
+++ b/src/Approval.sol
@@ -7,7 +7,7 @@ import {ERC20} from "./ERC20.sol";
 
 contract ApprovalRaceToken is ERC20 {
     // --- Init ---
-    constructor(uint _totalSupply) ERC20(_totalSupply) public {}
+    constructor(uint _totalSupply) ERC20(_totalSupply) {}
 
     // --- Token ---
     function approve(address usr, uint wad) override public returns (bool) {

--- a/src/ApprovalToZero.sol
+++ b/src/ApprovalToZero.sol
@@ -7,7 +7,7 @@ import {ERC20} from "./ERC20.sol";
 
 contract ApprovalToZeroToken is ERC20 {
     // --- Init ---
-    constructor(uint _totalSupply) ERC20(_totalSupply) public {}
+    constructor(uint _totalSupply) ERC20(_totalSupply) {}
 
     // --- Token ---
     function approve(address usr, uint wad) override public returns (bool) {

--- a/src/BlockList.sol
+++ b/src/BlockList.sol
@@ -16,7 +16,7 @@ contract BlockableToken is ERC20 {
     function allow(address usr) auth public { blocked[usr] = false; }
 
     // --- Init ---
-    constructor(uint _totalSupply) ERC20(_totalSupply) public {
+    constructor(uint _totalSupply) ERC20(_totalSupply) {
         owner = msg.sender;
     }
 

--- a/src/Bytes32Metadata.sol
+++ b/src/Bytes32Metadata.sol
@@ -27,7 +27,7 @@ contract ERC20 is Math {
     event Transfer(address indexed src, address indexed dst, uint wad);
 
     // --- Init ---
-    constructor(uint _totalSupply) public {
+    constructor(uint _totalSupply) {
         totalSupply = _totalSupply;
         balanceOf[msg.sender] = _totalSupply;
         emit Transfer(address(0), msg.sender, _totalSupply);

--- a/src/DaiPermit.sol
+++ b/src/DaiPermit.sol
@@ -38,7 +38,7 @@ contract DaiPermit is Math {
     event Transfer(address indexed src, address indexed dst, uint wad);
 
     // --- Init ---
-    constructor(uint _totalSupply) public {
+    constructor(uint _totalSupply) {
         totalSupply = _totalSupply;
         balanceOf[msg.sender] = _totalSupply;
         emit Transfer(address(0), msg.sender, _totalSupply);

--- a/src/ERC20.sol
+++ b/src/ERC20.sol
@@ -27,7 +27,7 @@ contract ERC20 is Math {
     event Transfer(address indexed src, address indexed dst, uint wad);
 
     // --- Init ---
-    constructor(uint _totalSupply) public {
+    constructor(uint _totalSupply) {
         totalSupply = _totalSupply;
         balanceOf[msg.sender] = _totalSupply;
         emit Transfer(address(0), msg.sender, _totalSupply);

--- a/src/HighDecimals.sol
+++ b/src/HighDecimals.sol
@@ -6,7 +6,7 @@ pragma solidity >=0.6.12;
 import {ERC20} from "./ERC20.sol";
 
 contract HighDecimalToken is ERC20 {
-    constructor(uint _totalSupply) ERC20(_totalSupply) public {
+    constructor(uint _totalSupply) ERC20(_totalSupply) {
         decimals = 30;
     }
 }

--- a/src/LowDecimals.sol
+++ b/src/LowDecimals.sol
@@ -6,7 +6,7 @@ pragma solidity >=0.6.12;
 import {ERC20} from "./ERC20.sol";
 
 contract LowDecimalToken is ERC20 {
-    constructor(uint _totalSupply) ERC20(_totalSupply) public {
+    constructor(uint _totalSupply) ERC20(_totalSupply) {
         decimals = 2;
     }
 }

--- a/src/MissingReturns.sol
+++ b/src/MissingReturns.sol
@@ -25,7 +25,7 @@ contract MissingReturnToken {
     }
 
     // --- Init ---
-    constructor(uint _totalSupply) public {
+    constructor(uint _totalSupply) {
         totalSupply = _totalSupply;
         balanceOf[msg.sender] = _totalSupply;
         emit Transfer(address(0), msg.sender, _totalSupply);

--- a/src/NoRevert.sol
+++ b/src/NoRevert.sol
@@ -17,7 +17,7 @@ contract NoRevertToken {
     event Transfer(address indexed src, address indexed dst, uint wad);
 
     // --- Init ---
-    constructor(uint _totalSupply) public {
+    constructor(uint _totalSupply) {
         totalSupply = _totalSupply;
         balanceOf[msg.sender] = _totalSupply;
         emit Transfer(address(0), msg.sender, _totalSupply);

--- a/src/Pausable.sol
+++ b/src/Pausable.sol
@@ -16,7 +16,7 @@ contract PausableToken is ERC20 {
     function start() auth external { live = true; }
 
     // --- Init ---
-    constructor(uint _totalSupply) ERC20(_totalSupply) public {
+    constructor(uint _totalSupply) ERC20(_totalSupply) {
         owner = msg.sender;
     }
 

--- a/src/Proxied.sol
+++ b/src/Proxied.sol
@@ -36,7 +36,7 @@ contract ProxiedToken {
     }
 
     // --- Init ---
-    constructor(uint _totalSupply) public {
+    constructor(uint _totalSupply) {
         admin[msg.sender] = true;
         totalSupply = _totalSupply;
         balanceOf[msg.sender] = _totalSupply;
@@ -99,7 +99,7 @@ contract ProxiedToken {
 
 contract TokenProxy {
     address payable immutable public impl;
-    constructor(address _impl) public {
+    constructor(address _impl) {
         impl = payable(_impl);
     }
 

--- a/src/Reentrant.sol
+++ b/src/Reentrant.sol
@@ -7,7 +7,7 @@ import {ERC20} from "./ERC20.sol";
 
 contract ReentrantToken is ERC20 {
     // --- Init ---
-    constructor(uint _totalSupply) ERC20(_totalSupply) public {}
+    constructor(uint _totalSupply) ERC20(_totalSupply) {}
 
     // --- Call Targets ---
     mapping (address => Target) public targets;

--- a/src/ReturnsFalse.sol
+++ b/src/ReturnsFalse.sol
@@ -25,7 +25,7 @@ contract ReturnsFalseToken {
     }
 
     // --- Init ---
-    constructor(uint _totalSupply) public {
+    constructor(uint _totalSupply) {
         totalSupply = _totalSupply;
         balanceOf[msg.sender] = _totalSupply;
         emit Transfer(address(0), msg.sender, _totalSupply);

--- a/src/RevertToZero.sol
+++ b/src/RevertToZero.sol
@@ -7,7 +7,7 @@ import {ERC20} from "./ERC20.sol";
 
 contract RevertToZeroToken is ERC20 {
     // --- Init ---
-    constructor(uint _totalSupply) ERC20(_totalSupply) public {}
+    constructor(uint _totalSupply) ERC20(_totalSupply) {}
 
     // --- Token ---
     function transferFrom(address src, address dst, uint wad) override public returns (bool) {

--- a/src/RevertZero.sol
+++ b/src/RevertZero.sol
@@ -7,7 +7,7 @@ import {ERC20} from "./ERC20.sol";
 
 contract RevertZeroToken is ERC20 {
     // --- Init ---
-    constructor(uint _totalSupply) ERC20(_totalSupply) public {}
+    constructor(uint _totalSupply) ERC20(_totalSupply) {}
 
     // --- Token ---
     function transferFrom(address src, address dst, uint wad) override public returns (bool) {

--- a/src/TransferFee.sol
+++ b/src/TransferFee.sol
@@ -10,7 +10,7 @@ contract TransferFeeToken is ERC20 {
     uint immutable fee;
 
     // --- Init ---
-    constructor(uint _totalSupply, uint _fee) ERC20(_totalSupply) public {
+    constructor(uint _totalSupply, uint _fee) ERC20(_totalSupply) {
         fee = _fee;
     }
 

--- a/src/TransferFromSelf.sol
+++ b/src/TransferFromSelf.sol
@@ -27,7 +27,7 @@ contract TransferFromSelfToken is Math {
     event Transfer(address indexed src, address indexed dst, uint wad);
 
     // --- Init ---
-    constructor(uint _totalSupply) public {
+    constructor(uint _totalSupply) {
         totalSupply = _totalSupply;
         balanceOf[msg.sender] = _totalSupply;
         emit Transfer(address(0), msg.sender, _totalSupply);

--- a/src/Uint96.sol
+++ b/src/Uint96.sol
@@ -29,7 +29,7 @@ contract Uint96ERC20 {
     }
 
     // --- Init ---
-    constructor(uint96 _supply) public {
+    constructor(uint96 _supply) {
         supply = _supply;
         balances[msg.sender] = _supply;
         emit Transfer(address(0), msg.sender, _supply);

--- a/src/Upgradable.sol
+++ b/src/Upgradable.sol
@@ -11,7 +11,7 @@ contract Proxy {
 
     // --- init ---
 
-    constructor(uint totalSupply) public {
+    constructor(uint totalSupply) {
 
         // Manual give()
         bytes32 slot = ADMIN_KEY;

--- a/src/test.t.sol
+++ b/src/test.t.sol
@@ -17,7 +17,7 @@ interface ERC20 {
 
 contract User {
     ERC20 token;
-    constructor(ERC20 _token) public {
+    constructor(ERC20 _token) {
         token = _token;
     }
 


### PR DESCRIPTION
Fixed a bunch of warnings appearing due to the constructors in this repo being `public`.
![Screenshot 2023-03-01 at 13 58 59](https://user-images.githubusercontent.com/86567384/222106467-8fb2f879-1abd-4b5f-a67e-db68f4194f1a.png)
